### PR TITLE
Make 'publicPath' relative

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     path: 'build',
     filename: 'bundle.js',
     chunkFilename: '[id].js',
-    publicPath: '/build/'
+    publicPath: 'build/'
   },
 
   resolve: {


### PR DESCRIPTION
This fixes async chunk loading on Windows. Can't test this on a posix environment at the moment.

Edit: before this change, I see the following in-browser error (Chrome):

```
GET file:///C:/build/1.js net::ERR_FILE_NOT_FOUND
```
