### PR TITLE
Better formatting for errors and filter non relevant ones

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,14 +99,16 @@ function hasExtensionError(d){
   return d.messageText.indexOf('must have extension') > -1;
 }
 
-function extensionErrorFilter(d) {
+function extensionErrorFilter(errors) {
   var otherErrors = !errors.every(hasExtensionError);
-  return !(otherErrors && hasExtensionError(d)); 
+  return function(d) {
+    return !(otherErrors && hasExtensionError(d));
+  } 
 }
 
 function formatErrors(errors) {
   return errors
-    .filter(extensionErrorFilter)
+    .filter(extensionErrorFilter(errors))
     .map(function(diagnostic) {
       var lineChar;
       if (diagnostic.file) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,22 +95,32 @@ function codegenErrorReport(errors) {
     .join('\n');
 }
 
+function hasExtensionError(d){
+  return d.messageText.indexOf('must have extension') > -1;
+}
+
+function extensionErrorFilter(d) {
+  var otherErrors = !errors.every(hasExtensionError);
+  return !(otherErrors && hasExtensionError(d)); 
+}
+
 function formatErrors(errors) {
-  return errors.map(function(diagnostic) {
-    var lineChar;
-    if (diagnostic.file) {
-      lineChar = diagnostic.file.getLineAndCharacterFromPosition(diagnostic.start);
-    }
-    return (
-      (diagnostic.file ? diagnostic.file.filename + ' ' : '')
-      + (lineChar ? formatLineChar(lineChar) + ' ': '')
-      + diagnostic.messageText
-    );
-  });
+  return errors
+    .filter(extensionErrorFilter)
+    .map(function(diagnostic) {
+      var lineChar;
+      if (diagnostic.file) {
+        lineChar = diagnostic.file.getLineAndCharacterFromPosition(diagnostic.start);
+      }
+      return (
+        (lineChar ? formatLineChar(lineChar) + ' ': '')
+        + diagnostic.messageText
+      );
+    });
 }
 
 function formatLineChar(lineChar) {
-  return '(' + lineChar.line + ', ' + lineChar.character + ')';
+  return '(Line: ' + lineChar.line + ', Char: ' + lineChar.character + ')';
 }
 
 module.exports = typescriptLoader;


### PR DESCRIPTION
This PR dials back the error formatting and certain types of errors coming out of typescript.

Although it is probably a symptom of #13, we currently generate a lot of errors with not useful information in the form of `File '{{ longFileName}}' must have extension '.ts' or '.d.ts'.`.

These are all the errors generated from calling an undefined method in one place in the code:
![Imgur](http://i.imgur.com/LOnplMS.png?1)

New Output:
![Imgur](http://i.imgur.com/os1GQTs.png?1)
